### PR TITLE
Do not raise on DisposableMail.include? nil

### DIFF
--- a/lib/disposable_mail/disposable.rb
+++ b/lib/disposable_mail/disposable.rb
@@ -2133,6 +2133,7 @@ module DisposableMail
 
     # Check if a mail is disposable (if it's domain is in the list)
     def include?(mail)
+      return false if mail.nil?
       domain = mail[/@(.+)/, 1]
       list.bsearch { |d| domain <=> d }
     end

--- a/lib/disposable_mail/version.rb
+++ b/lib/disposable_mail/version.rb
@@ -1,3 +1,3 @@
 module DisposableMail
-  VERSION = '0.1.5'
+  VERSION = '0.1.6'
 end

--- a/test/disposable_mail_tests.rb
+++ b/test/disposable_mail_tests.rb
@@ -21,5 +21,6 @@ class TestDisposableMail < MiniTest::Test
 
     refute DisposableMail.include? "legit-person@yahoo.com"
     refute DisposableMail.include? "someone@gmail.com"
+    refute DisposableMail.include? nil
   end
 end


### PR DESCRIPTION
If you pass nil to include? it should return false instead of `NoMethodError: undefined method `[]' for nil:NilClass`.

This fixes validates :email, undisposable: when user.email can be nil (admittedly an edge case).