### PR TITLE
fix adding error on ruby 3.0

### DIFF
--- a/lib/disposable_mail/rails/validator.rb
+++ b/lib/disposable_mail/rails/validator.rb
@@ -1,7 +1,7 @@
 class UndisposableValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     if DisposableMail.include?(value)
-      record.errors.add(attribute, :undisposable, options)
+      record.errors.add(attribute, :undisposable, **options)
     end
   end
 end


### PR DESCRIPTION
After updating to ruby 3.0, when adding errors there are an error. It's easy to fix - it requires to set explicity key on options.